### PR TITLE
fix: remove overflow hidden to ItemCard to fix android render

### DIFF
--- a/market-test-immfly/src/components/ItemCard.tsx
+++ b/market-test-immfly/src/components/ItemCard.tsx
@@ -43,8 +43,6 @@ const ItemCard: React.FC<ItemCardProps> = ({ id, title, price, stock, selected, 
         }
     }, [quantity]);
 
-
-
     // Handle card selection
     const handleSelect = () => {
         if (isDisabled) return;
@@ -257,7 +255,6 @@ const styles = StyleSheet.create({
         aspectRatio: 1,
         marginBottom: 8,
         borderRadius: SIZES.radius,
-        overflow: 'hidden',
         backgroundColor: COLORS.white,
     },
     cardSelected: {


### PR DESCRIPTION
# Description

This PR fixes the **ItemCard display issue** where the card content turned blank when selecting another item, caused by improper use of `overflow: hidden` on **Android**.

---

# Tasks 

- [x] Investigate and identify cause of ItemCard blank display

---

# Demo

